### PR TITLE
Read external tool output properly

### DIFF
--- a/asset_bundler.rb
+++ b/asset_bundler.rb
@@ -289,7 +289,12 @@ END
             i.puts(@content)
             i.close_write()
           end
-          @content = i.gets() if !outfile
+          if !outfile
+            @content = ""
+            i.each {|line|
+              @content << line
+            }
+          end
         }
       end
 


### PR DESCRIPTION
gets() was only reading one single line, but when the CSS/JS files
contain comments the output can have more than one line.
