### PR TITLE
Added fake content in script tags

### DIFF
--- a/asset_bundler.rb
+++ b/asset_bundler.rb
@@ -324,9 +324,9 @@ END
       return dev_markup() if @config['dev']
       case @type
         when 'js'
-          "<script type='text/javascript' src='#{@base}#{@filename}'></script>\n"
+          "<script type='text/javascript' src='#{@base}#{@filename}'> </script>\n"
         when 'coffee'
-          "<script type='text/coffeescript' src='#{@base}#{@filename}'></script>\n"
+          "<script type='text/coffeescript' src='#{@base}#{@filename}'> </script>\n"
         when 'css'
           "<link rel='stylesheet' type='text/css' href='#{@base}#{@filename}' />\n"
         when 'less'
@@ -339,9 +339,9 @@ END
       @files.each {|f|
         case @type
           when 'js'
-            output.concat("<script type='text/javascript' src='#{f}'></script>\n")
+            output.concat("<script type='text/javascript' src='#{f}'> </script>\n")
           when 'coffee'
-            output.concat("<script type='text/coffeescript' src='#{f}'></script>\n")
+            output.concat("<script type='text/coffeescript' src='#{f}'> </script>\n")
           when 'css'
             output.concat("<link rel='stylesheet' type='text/css' href='#{f}' />\n")
           when 'less'


### PR DESCRIPTION
When I tried to bundle a few JS files inside of an article the result was somehow <script ... /> instead of <script></script>. My browser (Chromium on Linux) stopped parsing at that point. Adding the space as fake content prevents this "optimization" from happening.
