### PR TITLE
Fixing an error with Jekyll 0.12.0

### DIFF
--- a/asset_bundler.rb
+++ b/asset_bundler.rb
@@ -247,8 +247,14 @@ END
     end
 
     def cache_dir()
-      cache_dir = File.expand_path( "./_asset_bundler_cache",
-                                    @context.registers[:site].source )
+	    plugin_conf = @context.registers[:site].plugins
+			# Hack for jekyll versions before 0.12.0
+			if plugin_conf.kind_of?(Array)
+			  plugin_dir = plugin_conf.first
+		  else
+		    plugin_dir = plugin_conf
+		  end
+      cache_dir = File.expand_path( "../_asset_bundler_cache", plugin_dir)
       if( !File.directory?(cache_dir) )
         FileUtils.mkdir_p(cache_dir)
       end


### PR DESCRIPTION
Fixes #9

Forcing the plugins path to be casted in String, as it was returned as an Array.

Maybe not the best fix, but it worked for me
