### PR TITLE
Introduce `bundle_name` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ following represents the default configuration:
       server_url:
       remove_bundled: false
       dev: false
+      bundle_name: false
       markup_templates:
         js: "<script type='text/javascript' src='{{url}}'></script>\n"
         css: "<link rel='stylesheet' type='text/css' href='{{url}}' />\n"
@@ -233,6 +234,12 @@ Dev mode is also automatically enabled when using
 is set to true.
 
 Default: `false`.
+
+### bundle_name:
+
+Overwrites bundle name. When false, MD5 hash of the content is used instead.
+
+Default: `false`
 
 ### markup_templates:
 

--- a/asset_bundler.rb
+++ b/asset_bundler.rb
@@ -229,7 +229,7 @@ END
         end
       }
 
-      @hash = Digest::MD5.hexdigest(@content)
+      @hash = @config['bundle_name'] || Digest::MD5.hexdigest(@content)
       @filename = "#{@hash}.#{@type}"
       cache_file = File.join(cache_dir(), @filename)
 


### PR DESCRIPTION
A classical approach to JS/CSS bundles is to use a hash of the file content as a filename and attach 'Cache-Control: max-age=31556900' or 'Expires' HTTP header.

Now imagine a website with 100 HTML pages. All of them include js like so:

```
<script scr="95a78b02de98.js"></script>
```

When JS changes, the hash of the file changes too, causing all HTML files that uses that JS to change as well.

One solution to this problem would be to stop using hashes as filenames.
## 

I use `bundle_name` option on [n12v.com](http://n12v.com/) where PJAX is used heavily. JS doesn’t get requested when user navigates between pages but HTML does. It makes more sense to don’t use MD5 hashes for bundle names.
