### PR TITLE
new config option "servenodev" to serve compressed locally

### DIFF
--- a/asset_bundler.rb
+++ b/asset_bundler.rb
@@ -197,7 +197,11 @@ END
 
         # Let's assume that when flag 'watch' or 'serving' is enabled, we want dev mode
         if context.registers[:site].config['serving'] || context.registers[:site].config['watch']
-          ret_config['dev'] = true
+          # ... unless we set servenodev to 'true' in config
+          if !ret_config['servenodev']
+            ret_config['dev'] = true
+          end
+
         end
 
         @@current_config = ret_config


### PR DESCRIPTION
there is apparently no way to see compressed versions of assets when just doing a "jekyll serve" locally. this new param "servenodev" allows to enable this
