### PR TITLE
Add support for closure compiler's advanced optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ modify compression behavior.
 
 To compress with the yui-compressor gem, use 'yui' here,
 to compress with the closure compiler gem, use 'closure' here.
+Use 'closure_advanced' to compress with the closure compiler gem using [ADVANCED_OPTIMIZATIONS](https://developers.google.com/closure/compiler/docs/compilation_levels#advanced_optimizations).
 
     compress:
       js: yui
@@ -196,6 +197,14 @@ specifying a command as outlined above.
 
 Takes the exact same arguments as `js:`, with the exception
 of the Google Closure Compiler ( it's JavaScript only ).
+
+#### js_externs:
+
+When using closure compiler with [ADVANCED_OPTIMIZATIONS](https://developers.google.com/closure/compiler/docs/compilation_levels#advanced_optimizations) enabled (see above), externs files can be passed to the compiler:
+
+    js_externs:
+        - path/to/externs.js
+        - other/path/to/externs.js
 
 ### base_path:
 

--- a/asset_bundler.rb
+++ b/asset_bundler.rb
@@ -316,7 +316,12 @@ END
         when 'yui'
           compress_yui()
         when 'closure'
-          compress_closure()
+          compress_closure({})
+        when 'closure_advanced'
+          compress_closure({
+            :compilation_level => 'ADVANCED_OPTIMIZATIONS',
+            :externs => (@config['compress']['js_externs'] || []).map { |d| File.join(@context.registers[:site].source, d) }
+          })
         else
           compress_command()
       end
@@ -383,11 +388,11 @@ END
       end
     end
 
-    def compress_closure()
+    def compress_closure(closure_args)
       require 'closure-compiler'
       case @type
         when 'js'
-          @content = Closure::Compiler.new.compile(@content)
+          @content = Closure::Compiler.new(closure_args).compile(@content)
       end
     end
 

--- a/asset_bundler.rb
+++ b/asset_bundler.rb
@@ -243,7 +243,8 @@ END
 
       @hash = @config['bundle_name'] || Digest::MD5.hexdigest(@content)
       @filename = "#{@hash}.#{@type}"
-      cache_file = File.join(cache_dir(), @filename)
+      cache_hash = Digest::MD5.hexdigest("#{@filename}#{@config['compress']}");
+      cache_file = File.join(cache_dir(), "#{cache_hash}.#{@type}")
 
       if File.readable?(cache_file) and @config['compress'][@type]
         @content = File.read(cache_file)


### PR DESCRIPTION
This pull request adds support for closure compiler's [advanced optimizations](https://developers.google.com/closure/compiler/docs/compilation_levels#advanced_optimizations) to the asset bundler. See updated [README](README.md) for details on added configuration options.
